### PR TITLE
BP-21973 | Pass the --recursive flag to license_finder

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,4 +9,4 @@ if [ -f Gemfile.lock ]; then
   gem install bundler -v 2.1.4
 fi
 
-$CMD_PREFIX license_finder
+$CMD_PREFIX license_finder --recursive


### PR DESCRIPTION
[BP-21973](https://boldpenguin.atlassian.net/browse/BP-21973)

This PR updates the `run.sh` script to pass the `--recursive` flag to `license_finder`. This change is an alternative to chdir'ing to another directory to run `license_finder`.  It's possible that it will fail existing builds, but that might not be a bad thing.

![2022-04-29_07-54](https://user-images.githubusercontent.com/760949/165959623-627c217a-c0dd-41ac-a8e5-9f759fe07b5e.png)

The output at the end is just to show that the command is working.