### PR TITLE
BP-22100 | Second attempt at passing the --recursive flag

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 CMD_PREFIX=""
+ARGS=""
 
 if [ -f Gemfile.lock ]; then
   CMD_PREFIX="bundle _2.1.4_ exec"
@@ -9,4 +10,8 @@ if [ -f Gemfile.lock ]; then
   gem install bundler -v 2.1.4
 fi
 
-$CMD_PREFIX license_finder
+if ! [ -z "$RECURSIVE" ]; then
+  ARGS="--recursive"
+fi
+
+$CMD_PREFIX license_finder $ARGS


### PR DESCRIPTION
Second attempt to pass the `--recursive` flag to `license_finder`.  This time it's only used if there is a `RECURSIVE` environment variable defined with a non-empty value.  This approach makes the flag opt-in, which avoids breaking runs in `partner-engine` and other repos.

![2022-05-24_10-21](https://user-images.githubusercontent.com/760949/170085371-ffd227a1-3f6d-4343-b3f3-80f48435e678.png)
