### PR TITLE
fix: BP-1 | Failing to run with Ruby 3.2.1

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,10 +4,7 @@ CMD_PREFIX=""
 ARGS=""
 
 if [ -f Gemfile.lock ]; then
-  CMD_PREFIX="bundle _2.1.4_ exec"
-  # Bundler has an issue, need to run using an old version
-  # https://github.com/pivotal/LicenseFinder/issues/828
-  gem install bundler -v 2.1.4
+  CMD_PREFIX="bundle exec"
 fi
 
 if ! [ -z "$RECURSIVE" ]; then


### PR DESCRIPTION
Currently fails with Ruby 3.2.1 in Partner Engine with the following error:

```
Fetching bundler-2.1.4.gem
Successfully installed bundler-2.1.4
1 gem installed
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Could not find mini_portile2-2.8.1 in any of the sources
Run `bundle install` to install missing gems.
```

See https://github.com/BoldPenguin/partner-engine/actions/runs/4138159472/jobs/7154221317

I have confirmed this change works in:
- Partner Engine with Ruby 3.2.1
- Authenticator with Ruby 3.1.2 (seems it is backwards compatible)