### PR TITLE
fix: BP-1 | Take 2 at fixing bundler issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,7 @@
 if [ -f Gemfile.lock ]; then
   bundle config unset deployment
   bundle add license_finder --group=development
+  bundle lock --add-platform x86_64-linux
 else
   gem install license_finder
 fi


### PR DESCRIPTION
My second take at solving missing dependencies. Seems my local environment doesn't mimic the GitHub actions environment well enough.

This comment suggested the fix: https://github.com/pivotal/LicenseFinder/issues/828#issuecomment-1082060981

So I updated the `.github/workflows/license.yml` in my [PE branch](https://github.com/BoldPenguin/partner-engine/pull/5016) to point to this branch...

```yaml
      - name: Check licenses
        uses: BoldPenguin/license-action@fix/bundler-take-2
        env:
          BP_GH_TOKEN: ${{ steps.get_token.outputs.app_token }}
```

I can confirm it now works:

![image](https://user-images.githubusercontent.com/4260509/217956648-d40b1499-c71f-432c-985d-ed052459dc14.png)
